### PR TITLE
added tar.gz build target

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -17,3 +17,4 @@ linux:
     - github
   target:
     - AppImage
+    - tar.gz


### PR DESCRIPTION
i just waned to have tar.gz on the release page makes it easier to integrate into AUR